### PR TITLE
Mention ssl lib if using on deployed app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Or download and run setup as normal:
     $ unzip notrequests.zip
     $ cd notrequests-master
     $ python setup.py install
+    
+Add `ssl` library to your App Engine app:
+
+    # app.yaml
+    libraries:
+    - name: ssl
+      version: 2.7
 
 
 Usage


### PR DESCRIPTION
Fails otherwise, because it tries to import `ssl`.
Not related to notrequests, but since it's App Engine specific, 
thought it would be good to mention.